### PR TITLE
Only install asyncio when necessary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asyncio
+asyncio;python_version<"3.4"
 aiohttp
 aiofiles
 requests

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'asyncio',
+        'asyncio;python_version<"3.4"',
         'aiohttp',
         'aiofiles',
         'requests'


### PR DESCRIPTION
Asyncio was added to the Python 3.4 standard library.  PyPI has a compatibily library for earlier versions, which should only be installed when necessary.